### PR TITLE
ドキュメントをGitHub Pagesで公開する設定

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,28 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:11
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            - v1-dependencies-
+
+      - run: yarn install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run: yarn docs:build
+
+      - run: sudo apt install -y rsync 
+
+      - run: ./.circleci/deploy.sh

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -eu
+
+echo "git clone"
+cd
+git clone $TARGET_REPO
+rsync -av -C --delete ~/repo/docs/.vuepress/dist/ ~/oauth2/
+cd ~/oauth2/
+
+echo "git commit"
+git config --global user.email "circleci@circleci.com"
+git config --global user.name "circleci"
+git add --all :/;
+git commit -m "deploy from circleci"
+
+echo "git push"
+ssh-keygen -y -f ~/.ssh/id_rsa > ~/.ssh/id_rsa.pub
+ssh-add -d
+git push

--- a/docs/.vuepress/config.js
+++ b/docs/.vuepress/config.js
@@ -1,6 +1,7 @@
 module.exports = {
   title: 'ALIS OAuth Document',
   description: 'ALIS OAuth Document',
+  base: "/oauth2/",
   themeConfig: {
     nav: [
       { text: 'Home', link: '/' },


### PR DESCRIPTION
以下の手順で公開可能です

1. このリポジトリをcircleciに登録
2. `oauth2`というレポジトリを用意
3. `oauth2`リポジトリのmasterブランチに[GitHub Pagesの設定](https://help.github.com/en/articles/configuring-a-publishing-source-for-github-pages)を行う
3. ssh鍵のペアを作成し、公開鍵を`oauth2`リポジトリのdeploy keyにwriteアクセス付きで追加
4. ssh鍵の秘密鍵を[circleciに設定](https://circleci.com/docs/2.0/add-ssh-key/)
5. circleciの環境変数 `TARGET_REPO` に `git@github.com:AlisProject/oauth2.git` を追加

これで、serverless-oauth-docs にpushされたら公開されます :bow:

実行サンプル
https://yaasita.github.io/oauth2/
