### PR TITLE
有効期限の確認はライブラリ側でやってました

### DIFF
--- a/docs/idtoken-verify/index.md
+++ b/docs/idtoken-verify/index.md
@@ -50,10 +50,6 @@ const iss = "https://alis.to/oauth2";
       jwt.decode(token, { complete: true }).header.kid
     );
     const decoded = jwt.verify(token, sig_key);
-    const now_unixtime = Math.floor(new Date().getTime() / 1000);
-    if (now_unixtime > decoded.exp) {
-      throw new Error("this idtoken is expired.");
-    }
     if (decoded.iss !== iss) {
       throw new Error(`this idtoken's iss is not ${iss}`);
     }


### PR DESCRIPTION
https://github.com/auth0/node-jsonwebtoken/blob/master/verify.js#L151-L153

なので、この判定は不要でした

こんなエラーがthrowされます
```
{ TokenExpiredError: jwt expired
    at /tmp/jwt/node_modules/jsonwebtoken/verify.js:152:21
    at getSecret (/tmp/jwt/node_modules/jsonwebtoken/verify.js:90:14)
    at Object.module.exports [as verify] (/tmp/jwt/node_modules/jsonwebtoken/verify.js:94:10)
    at /tmp/jwt/verify.js:13:25
    at process.internalTickCallback (internal/process/next_tick.js:77:7)
  name: 'TokenExpiredError',
  message: 'jwt expired',
  expiredAt: 2019-06-03T14:47:03.000Z }

```